### PR TITLE
fix set reply to

### DIFF
--- a/Message.php
+++ b/Message.php
@@ -125,7 +125,7 @@ class Message extends BaseMessage
      */
     public function setReplyTo($replyTo)
     {
-        $this->_replyTo [] = $replyTo;
+        $this->setRecipients('replyTo', $replyTo);
         return $this;
     }
 


### PR DESCRIPTION
the old code caused the error: Array into String on [getReplyToString](https://github.com/francisberesford/snapcms-yii2-mandrill/blob/master/Message.php#L366)
because `$address` will be
```php
$address = [
    '0' => [
        'tongtoan2704@gmail.com' => 'Jackson Tong'
    ]
];
```